### PR TITLE
Add TaskItem component and dummy task list

### DIFF
--- a/src/components/Taskitem.jsx
+++ b/src/components/Taskitem.jsx
@@ -1,0 +1,26 @@
+import { cva } from "class-variance-authority";
+
+// 入力フィールドのスタイルを定義
+const inputVariants = cva("flex-1 border px-2 py-1 border-gray-300, bg-white", {
+  variants: {
+    completed: {
+      true: "line-through text-gray-400 disabled:cursor-not-allowed",
+      // 完了したタスクのスタイル
+    },
+  },
+});
+
+export function TaskItem({ task }) {
+  return (
+    <div className="flex items-center gap-3 rounded bg-white px-4 py-2">
+      {/* タスクのタイトルを編集可能な入力フィールド */}
+      <input
+        type="text"
+        className={inputVariants({ completed: task.status === "completed" })}
+        // タスクが完了している場合のスタイルを適用
+        defaultValue={task.title} // タスクの現在のタイトルを表示
+        disabled={task.status === "completed"} // 完了したタスクの場合、編集を無効化
+      />
+    </div>
+  );
+}

--- a/src/data/dummyTaskList.js
+++ b/src/data/dummyTaskList.js
@@ -1,0 +1,17 @@
+export const dummyTaskList = [
+  {
+    id: 1,
+    title: "Reactを勉強する",
+    status: "notStarted",
+  },
+  {
+    id: 2,
+    title: "JavaScriptを勉強する",
+    status: "inProgress",
+  },
+  {
+    id: 3,
+    title: "TypeScriptを勉強する",
+    status: "completed",
+  },
+];


### PR DESCRIPTION
### 説明
タスク管理アプリケーションの初期開発として、以下の機能を追加しました。


   - `TaskItem` コンポーネントの追加:
       - 個々のタスクを表示するためのReactコンポーネント src/components/Taskitem.jsx を追加しました。
       - タスクのタイトルを表示し、完了状態に応じてスタイルが適用されるように class-variance-authority を使用しています。
       - 完了したタスクは取り消し線が引かれ、編集不可になります。


   - ダミーデータ `dummyTaskList.js` の追加:
       - アプリケーションの動作確認用に、ダミーのタスクリストを src/data/dummyTaskList.js に追加しました。
       - これにより、TaskItem コンポーネントが実際にタスクデータを表示できることを確認できます。


  目的:
  タスク管理アプリケーションのUIコンポーネントの基盤を構築し、ダミーデータを用いて表示機能を検証することを目的としています。


  変更内容:
   - src/components/Taskitem.jsx を新規作成
   - src/data/dummyTaskList.js を新規作成
  ---

<!--
このPRの説明
画像や動画(GIF)、APIの利用方法など書いてあると良い
-->

### 関連

<!--
関連するIssueやBacklogなどへのリンク
-->

### 共有事項(Shared Matters)

<!--
何か共有したいこと、残タスク等あれば
-->

### レビュワーの方へ（For Reviewers）
<!--
レビュー優先度が「至急/なる早」の場合はPRにレビュー優先度のラベルも設定すること
-->
- レビュー優先度(Priority): 通常
- 目安期間(Limit): 本日
- リリース日(Release Date): 未定
- QA開始予定日(QA Start Date): 未定