### PR TITLE
ローカルストレージによるタスクデータの永続化

### DIFF
--- a/src/components/TaskList.jsx
+++ b/src/components/TaskList.jsx
@@ -1,10 +1,19 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CreateTaskForm } from "./CreateTaskForm";
 import { TaskItem } from "./TaskItem";
 
 export function TaskList() {
   // タスク一覧の状態を管理
-  const [taskList, setTaskList] = useState([]);
+  const [taskList, setTaskList] = useState(() => {
+    // ローカルストレージから "taskList" のデータを取得
+    const taskListStorage = localStorage.getItem("taskList");
+    // ローカルストレージにデータがあれば、それをパースして返し、なければからの配列を返す
+    return JSON.parse(taskListStorage ?? "[]");
+  });
+
+  useEffect(() => {
+    localStorage.setItem("taskList", JSON.stringify(taskList));
+  }, [taskList]);
 
   // 新しいタスクを追加
   const createTask = (title) => {

--- a/src/hooks/useLocalStorageState.js
+++ b/src/hooks/useLocalStorageState.js
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+export function useLocalStorageState(key, initialValue) {
+  const [state, setState] = useState(() => {
+    // ローカルストレージから初期値を取得
+    const storedValue = localStorage.getItem(key);
+    return storedValue !== null ? JSON.parse(storedValue) : initialValue;
+  });
+
+  const setLocalStorageState = (value) => {
+    setState((prevState) => {
+      // 新しい状態を計算
+      const newState =
+        typeof value === 'function' ? value(prevState) : value; // 関数の場合、現在の状態を引数にして呼び出し
+
+      // ローカルストレージに新しい状態を保存
+      localStorage.setItem(key, JSON.stringify(newState));
+
+      // 新しい状態を返して状態を更新
+      return newState;
+    });
+  };
+
+  return [state, setLocalStorageState];
+}

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -1,0 +1,32 @@
+import { useLocalStorageState } from "./useLocalStorageState";
+
+export function useTasks() {
+  const [taskList, setTaskList] = useLocalStorageState("tasks", []);
+
+  const activeTaskList = taskList.filter(({ status }) => status === "trashed");
+
+  // タスクを作成する
+  const createTask = (title) => {
+    setTaskList((prevTaskList) => {
+      const newTask = {
+        id: Date.now(),
+        title,
+        status: "notStarted",
+      };
+      return [...prevTaskList, newTask];
+    });
+  };
+
+  // タスクを更新する
+  const updateTask = (id, updatedTask) => {
+    setTaskList((prevTaskList) => {
+      return prevTaskList.map((task) => (task.id === id ? { ...task, ...updatedTask } : task));
+    });
+  };
+
+  return {
+    activeTaskList,
+    createTask,
+    updateTask,
+  };
+}


### PR DESCRIPTION
### 説明
タスク管理アプリのデータをブラウザのローカルストレージに保存し、ページをリロードしてもデータが保持されるように機能を改善しました。これ
  により、ユーザーはアプリケーションを閉じてもタスク情報を失うことがなくなります。

  変更のポイント

   - `useLocalStorageState` カスタムフックの導入:
    状態(state)をローカルストレージと同期させるためのカスタムフック useLocalStorageState を新規に作成しました。


   - タスク管理への適用:
    タスクのリストを管理する箇所で、従来の useState に代わってこの useLocalStorageState フックを使用するように変更しました。

  影響


   - タスクの追加、更新、削除といった全ての操作結果が、自動的にローカルストレージに保存・反映されます。
   - アプリケーション起動時にローカルストレージからデータを読み込むため、前回の状態が復元されます。

  ---

<!--
このPRの説明
画像や動画(GIF)、APIの利用方法など書いてあると良い
-->

### 関連

<!--
関連するIssueやBacklogなどへのリンク
-->

### 共有事項(Shared Matters)

<!--
何か共有したいこと、残タスク等あれば
-->

### レビュワーの方へ（For Reviewers）
<!--
レビュー優先度が「至急/なる早」の場合はPRにレビュー優先度のラベルも設定すること
-->
- レビュー優先度(Priority): 通常
- 目安期間(Limit): 本日
- リリース日(Release Date): 未定
- QA開始予定日(QA Start Date): 未定